### PR TITLE
Fix cycle-triggering bug in handle_info() processing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: erlang
 install: true
 otp_release:
-- R16B02
 - 17.1
+- 23.0
 
 script: make deps compile test

--- a/test/gen_cycle_SUITE.erl
+++ b/test/gen_cycle_SUITE.erl
@@ -9,7 +9,8 @@ all() ->
      t_info_handled,
      t_callback_stop,
      t_callback_hibernated,
-     t_start_named_supervised
+     t_start_named_supervised,
+     t_handle_info_does_not_trigger_new_cycle
      ].
 
 suite() ->
@@ -98,3 +99,45 @@ t_start_named_supervised(_Config) ->
     Name = {local, named_cycle},
     {ok, _} = sample_cycle:start(Name, [timer:seconds(1)]),
     true = erlang:is_process_alive(whereis(named_cycle)).
+
+t_handle_info_does_not_trigger_new_cycle(_Config) ->
+    N = 50,
+    {ok, Pid} = limited5_cycle:start([self(), timer:seconds(1)]),
+    [begin
+         Pid ! i_need_this_back
+     end || _ <- lists:seq(1, N)],
+
+    timer:sleep(2100),
+    %% If handle_info() triggers new cycles, then it is very unlikely
+    %% that Pid will be alive.  If scheduler luck is horrible, it is
+    %% still alive, so we'll do more checking below.
+    true = erlang:is_process_alive(Pid),
+
+    Pid ! get_cycle_count,
+    receive
+        {get_cycle_count, 3} ->
+            %% tick 1 = immediately after init(), tick 2 = after 1 sec,
+            %% tick 3 = after 2 sec
+            ok
+    after timer:seconds(3) ->
+            %% Pid is probably not alive.  If Pid is still alive, then
+            %% the scheduler hates us.  Tell the test user what's in
+            %% our mailbox to debug the problem.
+            error({get_cycle_count_failure,
+                   alive, erlang:is_process_alive(Pid),
+                   mailbox, element(2, process_info(self(), messages))})
+    end,
+
+    Pid ! get_info_count,
+    receive
+        {get_info_count, N} ->
+            ok;
+        {get_info_count, Other2} ->
+            error({get_info_count_failure, got, Other2})
+    after timer:seconds(3) ->
+            %% The scheduler really hates us.
+            error({get_info_count_failure,
+                   alive, erlang:is_process_alive(Pid),
+                   mailbox, element(2, process_info(self(), messages))})
+    end,
+    ok.

--- a/test/limited5_cycle.erl
+++ b/test/limited5_cycle.erl
@@ -1,0 +1,32 @@
+-module(limited5_cycle).
+-behaviour(gen_cycle).
+
+-export([start/1, start/2,
+         init_cycle/1,
+         handle_cycle/1,
+         handle_info/2]).
+
+start(Args) ->
+    gen_cycle:start_supervised(?MODULE, Args).
+
+start(Name, Args) ->
+    gen_cycle:start_supervised(Name, ?MODULE, Args).
+
+init_cycle([TestProcess, Interval]) ->
+    {ok, {Interval, {TestProcess, 0, 0}}}.
+
+handle_cycle({TestProcess, 5 = CycleCount, InfoCount}) ->
+    {stop, {TestProcess, CycleCount, InfoCount}};
+handle_cycle({TestProcess, CycleCount, InfoCount}) ->
+    TestProcess ! cycle_handled,
+    {continue, {TestProcess, CycleCount + 1, InfoCount}}.
+
+handle_info(get_cycle_count, {TestProcess, CycleCount, _InfoCount} = State) ->
+    TestProcess ! {get_cycle_count, CycleCount},
+    {continue, State};
+handle_info(get_info_count, {TestProcess, _CycleCount, InfoCount} = State) ->
+    TestProcess ! {get_info_count, InfoCount},
+    {continue, State};
+handle_info(Msg, {TestProcess, CycleCount, InfoCount}) ->
+    TestProcess ! {info_handled, Msg},
+    {continue, {TestProcess, CycleCount, InfoCount + 1}}.


### PR DESCRIPTION
Before this PR, when `handle_info()` receives an unknown message, gen_cycle schedules sending a `$cycle` message (via `erlang:send_interval()`).  As more unknown messages are processed by `handle_info()`, it becomes more likely that there will always be a `$cycle` message in the mailbox.  Eventually, the gen_cycle process will always be running, instead of honoring the cycle interval that the process was configured with.  In the worst case, if `handle_info()` always generates at least one unknown message, then the gen_cycle's mailbox will grow without bound.

This PR schedules sending a `$cycle` message only after finishing processing of a `$cycle` message.  I've added a new CT test in the first commit that fails. The second commit fixes the bug and the test passes.  The CT tests rely on wall clock time + the BEAM scheduler to avoid being evil.  I didn't write the new test or rewrite any existing tests to remove the reliance on wall clock time.  I put some comments in the test case to explain the context of what scheduling problem went wrong in case of an unexpected result.